### PR TITLE
fix: fix issue "undefined method `next' for nil:NilClass"

### DIFF
--- a/lib/biz/periods/linear.rb
+++ b/lib/biz/periods/linear.rb
@@ -28,10 +28,13 @@ module Biz
             end
 
             yielder << begin
-              sequences
+              selected = sequences
                 .select(&:any?)
                 .public_send(selector) { |sequence| sequence.peek.date }
-                .next
+
+              break if selected.nil?
+
+              selected.next
             end
           end
 

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -361,6 +361,17 @@ RSpec.describe Biz::Schedule do
           schedule.within(Time.utc(2021, 12, 3, 12), Time.utc(2021, 12, 3, 15))
         ).to eq Biz::Duration.hours(2)
       end
+
+      it 'should return 0 if empty shifts were provided' do
+        schedule = Biz::Schedule.new do |config|
+          config.hours  = {}
+          config.shifts = {}
+        end
+
+        expect(
+          schedule.within(Time.utc(2021, 12, 3, 12), Time.utc(2021, 12, 3, 15))
+        ).to eq Biz::Duration.hours(0)
+      end
     end
 
     describe '#in_hours?' do


### PR DESCRIPTION
Fixes issue when empty `hours` and `shifts` are provided, querying `periods` will throw:
```ruby
sequences
  .select(&:any?)
  .public_send(selector) { |sequence| sequence.peek.date }
  .next
     
NoMethodError:
  undefined method `next' for nil:NilClass
```